### PR TITLE
[TRIS-299] enable server-side-encryption for s3 uploads

### DIFF
--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -70,7 +70,7 @@ S3_ENDPOINT_URL = from_conf("S3_ENDPOINT_URL")
 S3_VERIFY_CERTIFICATE = from_conf("S3_VERIFY_CERTIFICATE")
 
 # Dictionary containing configurable S3 upload settings
-# e.g. ServerSideEncryption, Tagging, StorageClass, etc. 
+# e.g. ServerSideEncryption, Tagging, StorageClass, etc.
 # List these parameters out using the prefix "METAFLOW_UPLOAD_ARGS_S3_[Key]".
 S3_UPLOAD_ARGS = from_conf("S3_UPLOAD_ARGS_", prefix=True)
 

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -69,8 +69,8 @@ CLIENT_CACHE_MAX_TASKDATASTORE_COUNT = from_conf(
 S3_ENDPOINT_URL = from_conf("S3_ENDPOINT_URL")
 S3_VERIFY_CERTIFICATE = from_conf("S3_VERIFY_CERTIFICATE")
 
-# Map for custom S3 upload settings
-# Can be used for things like ServerSideEncryption, Tagging, StorageClass, etc. 
+# S3 configurable settings (string of format "KEY=VALUE, KEY=VALUE, etc.")
+# e.g. ServerSideEncryption, Tagging, StorageClass, etc. 
 S3_CUSTOM_UPLOAD_SETTINGS = from_conf("CUSTOM_UPLOAD_SETTINGS_S3")
 
 # S3 retry configuration

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -68,7 +68,10 @@ CLIENT_CACHE_MAX_TASKDATASTORE_COUNT = from_conf(
 ###
 S3_ENDPOINT_URL = from_conf("S3_ENDPOINT_URL")
 S3_VERIFY_CERTIFICATE = from_conf("S3_VERIFY_CERTIFICATE")
-S3_SERVER_SIDE_ENCRYPTION = from_conf("S3_SERVER_SIDE_ENCRYPTION")
+
+# Map for custom S3 upload settings
+# Can be used for things like ServerSideEncryption, Tagging, StorageClass, etc. 
+S3_CUSTOM_UPLOAD_SETTINGS = from_conf("CUSTOM_UPLOAD_SETTINGS_S3")
 
 # S3 retry configuration
 # This is useful if you want to "fail fast" on S3 operations; use with caution

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -71,9 +71,8 @@ S3_VERIFY_CERTIFICATE = from_conf("S3_VERIFY_CERTIFICATE")
 
 # Dictionary containing configurable S3 upload settings
 # e.g. ServerSideEncryption, Tagging, StorageClass, etc. 
-# Use a JSON string to represent this parameter within an environment variable
-# and use a dictionary to represent this parameter within a JSON config file.
-S3_UPLOAD_ARGS = from_conf("UPLOAD_ARGS_S3", {})
+# List these parameters out using the prefix "METAFLOW_UPLOAD_ARGS_S3_[Key]".
+S3_UPLOAD_ARGS = from_conf("UPLOAD_ARGS_S3", {}, prefix=True)
 
 # S3 retry configuration
 # This is useful if you want to "fail fast" on S3 operations; use with caution

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -71,8 +71,8 @@ S3_VERIFY_CERTIFICATE = from_conf("S3_VERIFY_CERTIFICATE")
 
 # Dictionary containing configurable S3 upload settings
 # e.g. ServerSideEncryption, Tagging, StorageClass, etc. 
-# Use a JSON string to represent this parameter as an environment variable
-# and use a dictionary to represent this parameter in a JSON config file.
+# Use a JSON string to represent this parameter within an environment variable
+# and use a dictionary to represent this parameter within a JSON config file.
 S3_UPLOAD_ARGS = from_conf("UPLOAD_ARGS_S3", {})
 
 # S3 retry configuration

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -72,7 +72,7 @@ S3_VERIFY_CERTIFICATE = from_conf("S3_VERIFY_CERTIFICATE")
 # Dictionary containing configurable S3 upload settings
 # e.g. ServerSideEncryption, Tagging, StorageClass, etc. 
 # List these parameters out using the prefix "METAFLOW_UPLOAD_ARGS_S3_[Key]".
-S3_UPLOAD_ARGS = from_conf("UPLOAD_ARGS_S3", {}, prefix=True)
+S3_UPLOAD_ARGS = from_conf("UPLOAD_ARGS_S3_", {}, prefix=True)
 
 # S3 retry configuration
 # This is useful if you want to "fail fast" on S3 operations; use with caution

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -72,7 +72,7 @@ S3_VERIFY_CERTIFICATE = from_conf("S3_VERIFY_CERTIFICATE")
 # Dictionary containing configurable S3 upload settings
 # e.g. ServerSideEncryption, Tagging, StorageClass, etc. 
 # List these parameters out using the prefix "METAFLOW_UPLOAD_ARGS_S3_[Key]".
-S3_UPLOAD_ARGS = from_conf("UPLOAD_ARGS_S3_", {}, prefix=True)
+S3_UPLOAD_ARGS = from_conf("S3_UPLOAD_ARGS_", {}, prefix=True)
 
 # S3 retry configuration
 # This is useful if you want to "fail fast" on S3 operations; use with caution

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -73,8 +73,7 @@ S3_VERIFY_CERTIFICATE = from_conf("S3_VERIFY_CERTIFICATE")
 # e.g. ServerSideEncryption, Tagging, StorageClass, etc. 
 # Use a JSON string to represent this parameter as an environment variable
 # and use a dictionary to represent this parameter in a JSON config file.
-S3_CUSTOM_UPLOAD_SETTINGS = from_conf("CUSTOM_UPLOAD_SETTINGS_S3", default={})
-
+S3_UPLOAD_ARGS = from_conf("UPLOAD_ARGS_S3", {})
 
 # S3 retry configuration
 # This is useful if you want to "fail fast" on S3 operations; use with caution

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -69,9 +69,12 @@ CLIENT_CACHE_MAX_TASKDATASTORE_COUNT = from_conf(
 S3_ENDPOINT_URL = from_conf("S3_ENDPOINT_URL")
 S3_VERIFY_CERTIFICATE = from_conf("S3_VERIFY_CERTIFICATE")
 
-# S3 configurable settings (string of format "KEY=VALUE, KEY=VALUE, etc.")
+# Dictionary containing configurable S3 upload settings
 # e.g. ServerSideEncryption, Tagging, StorageClass, etc. 
-S3_CUSTOM_UPLOAD_SETTINGS = from_conf("CUSTOM_UPLOAD_SETTINGS_S3")
+# Use a JSON string to represent this parameter as an environment variable
+# and use a dictionary to represent this parameter in a JSON config file.
+S3_CUSTOM_UPLOAD_SETTINGS = from_conf("CUSTOM_UPLOAD_SETTINGS_S3", default={})
+
 
 # S3 retry configuration
 # This is useful if you want to "fail fast" on S3 operations; use with caution

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -68,6 +68,7 @@ CLIENT_CACHE_MAX_TASKDATASTORE_COUNT = from_conf(
 ###
 S3_ENDPOINT_URL = from_conf("S3_ENDPOINT_URL")
 S3_VERIFY_CERTIFICATE = from_conf("S3_VERIFY_CERTIFICATE")
+S3_SERVER_SIDE_ENCRYPTION = from_conf("S3_SERVER_SIDE_ENCRYPTION")
 
 # S3 retry configuration
 # This is useful if you want to "fail fast" on S3 operations; use with caution

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -72,7 +72,7 @@ S3_VERIFY_CERTIFICATE = from_conf("S3_VERIFY_CERTIFICATE")
 # Dictionary containing configurable S3 upload settings
 # e.g. ServerSideEncryption, Tagging, StorageClass, etc. 
 # List these parameters out using the prefix "METAFLOW_UPLOAD_ARGS_S3_[Key]".
-S3_UPLOAD_ARGS = from_conf("S3_UPLOAD_ARGS_", {}, prefix=True)
+S3_UPLOAD_ARGS = from_conf("S3_UPLOAD_ARGS_", prefix=True)
 
 # S3 retry configuration
 # This is useful if you want to "fail fast" on S3 operations; use with caution

--- a/metaflow/metaflow_config_funcs.py
+++ b/metaflow/metaflow_config_funcs.py
@@ -62,7 +62,7 @@ def from_conf(name, default=None, validate_fn=None, prefix=False):
     is_default = True
     env_name = "METAFLOW_%s" % name
     if prefix:
-        len_prefix = len(env_name) + 1
+        len_prefix = len(env_name)
         env_vars = {k[len_prefix:None]: v for k, v in os.environ.items() if k.startswith(env_name)}
         config_vars = {k[len_prefix:None]: v for k, v in METAFLOW_CONFIG.items() if k.startswith(env_name)}
         value = {**config_vars, **env_vars}

--- a/metaflow/metaflow_config_funcs.py
+++ b/metaflow/metaflow_config_funcs.py
@@ -63,8 +63,16 @@ def from_conf(name, default=None, validate_fn=None, prefix=False):
     env_name = "METAFLOW_%s" % name
     if prefix:
         len_prefix = len(env_name)
-        env_vars = {k[len_prefix:None]: v for k, v in os.environ.items() if k.startswith(env_name)}
-        config_vars = {k[len_prefix:None]: v for k, v in METAFLOW_CONFIG.items() if k.startswith(env_name)}
+        env_vars = {
+            k[len_prefix:None]: v
+            for k, v in os.environ.items()
+            if k.startswith(env_name)
+        }
+        config_vars = {
+            k[len_prefix:None]: v
+            for k, v in METAFLOW_CONFIG.items()
+            if k.startswith(env_name)
+        }
         value = {**config_vars, **env_vars}
     else:
         value = os.environ.get(env_name, METAFLOW_CONFIG.get(env_name, default))

--- a/metaflow/metaflow_config_funcs.py
+++ b/metaflow/metaflow_config_funcs.py
@@ -65,7 +65,7 @@ def from_conf(name, default=None, validate_fn=None, prefix=False):
         len_prefix = len(env_name) + 1
         env_vars = {k[len_prefix:None]: v for k, v in os.environ.items() if k.startswith(env_name)}
         config_vars = {k[len_prefix:None]: v for k, v in METAFLOW_CONFIG.items() if k.startswith(env_name)}
-        value= {**config_vars, **env_vars}
+        value = {**config_vars, **env_vars}
     else:
         value = os.environ.get(env_name, METAFLOW_CONFIG.get(env_name, default))
     if validate_fn and value is not None:

--- a/metaflow/metaflow_config_funcs.py
+++ b/metaflow/metaflow_config_funcs.py
@@ -65,7 +65,7 @@ def from_conf(name, default=None, validate_fn=None, prefix=False):
         len_prefix = len(env_name) + 1
         env_vars = {k[len_prefix:None]: v for k, v in os.environ.items() if k.startswith(env_name)}
         config_vars = {k[len_prefix:None]: v for k, v in METAFLOW_CONFIG.items() if k.startswith(env_name)}
-        value= {**env_vars, **config_vars}
+        value= {**config_vars, **env_vars}
     else:
         value = os.environ.get(env_name, METAFLOW_CONFIG.get(env_name, default))
     if validate_fn and value is not None:

--- a/metaflow/metaflow_config_funcs.py
+++ b/metaflow/metaflow_config_funcs.py
@@ -65,8 +65,6 @@ def from_conf(name, default=None, validate_fn=None, prefix=False):
         len_prefix = len(env_name) + 1
         env_vars = {k[len_prefix:None]: v for k, v in os.environ.items() if k.startswith(env_name)}
         config_vars = {k[len_prefix:None]: v for k, v in METAFLOW_CONFIG.items() if k.startswith(env_name)}
-        print('env', env_vars)
-        print('conf', config_vars)
         value= {**env_vars, **config_vars}
     else:
         value = os.environ.get(env_name, METAFLOW_CONFIG.get(env_name, default))

--- a/metaflow/metaflow_config_funcs.py
+++ b/metaflow/metaflow_config_funcs.py
@@ -49,7 +49,7 @@ def config_values(include=0):
             yield name, config_value.serializer(config_value.value)
 
 
-def from_conf(name, default=None, validate_fn=None):
+def from_conf(name, default=None, validate_fn=None, prefix=False):
     """
     First try to pull value from environment, then from metaflow config JSON
 
@@ -59,9 +59,17 @@ def from_conf(name, default=None, validate_fn=None):
     validate_fn should accept (name, value).
     If the value validates, return None, else raise an MetaflowException.
     """
-    env_name = "METAFLOW_%s" % name
     is_default = True
-    value = os.environ.get(env_name, METAFLOW_CONFIG.get(env_name, default))
+    env_name = "METAFLOW_%s" % name
+    if prefix:
+        len_prefix = len(env_name) + 1
+        env_vars = {k[len_prefix:None]: v for k, v in os.environ.items() if k.startswith(env_name)}
+        config_vars = {k[len_prefix:None]: v for k, v in METAFLOW_CONFIG.items() if k.startswith(env_name)}
+        print('env', env_vars)
+        print('conf', config_vars)
+        value= {**env_vars, **config_vars}
+    else:
+        value = os.environ.get(env_name, METAFLOW_CONFIG.get(env_name, default))
     if validate_fn and value is not None:
         validate_fn(env_name, value)
     if default is not None:

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -20,6 +20,7 @@ from metaflow.metaflow_config import (
     S3_ENDPOINT_URL,
     DEFAULT_SECRETS_BACKEND_TYPE,
     AWS_SECRETS_MANAGER_DEFAULT_REGION,
+    S3_UPLOAD_ARGS,
 )
 from metaflow.mflog import (
     export_mflog_env_vars,
@@ -246,6 +247,7 @@ class Batch(object):
             .environment_variable("METAFLOW_DEFAULT_METADATA", DEFAULT_METADATA)
             .environment_variable("METAFLOW_CARD_S3ROOT", CARD_S3ROOT)
             .environment_variable("METAFLOW_RUNTIME_ENVIRONMENT", "aws-batch")
+            .environment_variable("METAFLOW_S3_UPLOAD_ARGS", S3_UPLOAD_ARGS)
         )
         if DEFAULT_SECRETS_BACKEND_TYPE is not None:
             job.environment_variable(

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -247,7 +247,6 @@ class Batch(object):
             .environment_variable("METAFLOW_DEFAULT_METADATA", DEFAULT_METADATA)
             .environment_variable("METAFLOW_CARD_S3ROOT", CARD_S3ROOT)
             .environment_variable("METAFLOW_RUNTIME_ENVIRONMENT", "aws-batch")
-            .environment_variable("METAFLOW_S3_UPLOAD_ARGS", S3_UPLOAD_ARGS)
         )
         if DEFAULT_SECRETS_BACKEND_TYPE is not None:
             job.environment_variable(
@@ -263,6 +262,9 @@ class Batch(object):
 
         if tmpfs_enabled and tmpfs_tempdir:
             job.environment_variable("METAFLOW_TEMPDIR", tmpfs_path)
+
+        if S3_UPLOAD_ARGS is not None:
+            job.environment_variable("METAFLOW_S3_UPLOAD_ARGS_", S3_UPLOAD_ARGS)
 
         # Skip setting METAFLOW_DATASTORE_SYSROOT_LOCAL because metadata sync between the local user
         # instance and the remote AWS Batch instance assumes metadata is stored in DATASTORE_LOCAL_DIR

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -264,7 +264,9 @@ class Batch(object):
             job.environment_variable("METAFLOW_TEMPDIR", tmpfs_path)
 
         if S3_UPLOAD_ARGS is not None:
-            job.environment_variable("METAFLOW_S3_UPLOAD_ARGS_", S3_UPLOAD_ARGS)
+            for key, value in S3_UPLOAD_ARGS.items():
+                env_var = "METAFLOW_S3_UPLOAD_ARGS_" + key
+                job.environment_variable(env_var, value)
 
         # Skip setting METAFLOW_DATASTORE_SYSROOT_LOCAL because metadata sync between the local user
         # instance and the remote AWS Batch instance assumes metadata is stored in DATASTORE_LOCAL_DIR

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -776,7 +776,7 @@ class S3(object):
                 path=None,
                 size=info_results["size"],
                 content_type=info_results["content_type"],
-                encryption=info_results["ServerSideEncryption"],
+                encryption=info_results["encryption"],
                 metadata=info_results["metadata"],
                 last_modified=info_results["last_modified"],
             )

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -1305,6 +1305,8 @@ class S3(object):
                     }
                 if self._upload_args:
                     upload_args = self._upload_args
+                    if "ServerSideEncryption" in upload_args:
+                        store_info["encryption"] = upload_args["ServerSideEncryption"]
                     store_info.update(upload_args)
                 if not os.path.exists(path):
                     raise MetaflowS3NotFound("Local file not found: %s" % path)

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -1169,7 +1169,7 @@ class S3(object):
         else:
 
             def _head(s3, _):
-                s3.head_object(Bucket=src.netloc, Key=src.path.lstrip("/"))
+                s3.head_object(Bucket=src.netloc, Key=src.path.lstrip("/"), ExtraArgs=extra_args)
 
             try:
                 self._one_boto_op(_head, url, create_tmp_file=False)

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -17,7 +17,7 @@ from metaflow.metaflow_config import (
     DATATOOLS_S3ROOT,
     S3_RETRY_COUNT,
     S3_TRANSIENT_RETRY_COUNT,
-    S3_SERVER_SIDE_ENCRYPTION,
+    S3_CUSTOM_UPLOAD_SETTINGS,
     TEMPDIR,
 )
 from metaflow.util import (
@@ -476,7 +476,7 @@ class S3(object):
         If `run` is not specified, use this as the S3 prefix.
     """
     @classmethod  # check this decorator
-    def parse_s3_custom_settings(settings_str: Optional[str]):
+    def parse_custom_s3_settings(settings_str: Optional[str]):
         s3_settings = {}
         for setting in settings_str.split(","):
             setting = setting.strip()
@@ -484,7 +484,6 @@ class S3(object):
                 key, value = setting.split("=")
                 s3_settings[key.strip()] = value.strip()
         return s3_settings
-
 
     @classmethod
     def get_root_from_config(cls, echo, create_on_absent=True):
@@ -497,7 +496,7 @@ class S3(object):
         prefix: Optional[str] = None,
         run: Optional[Union[FlowSpec, "Run"]] = None,
         s3root: Optional[str] = None,
-        encryption: Optional[str] = S3_SERVER_SIDE_ENCRYPTION,
+        settings: Optional[str] = S3_CUSTOM_UPLOAD_SETTINGS,
         **kwargs
     ):
         if not boto_found:
@@ -551,7 +550,7 @@ class S3(object):
             "inject_failure_rate", TEST_INJECT_RETRYABLE_FAILURES
         )
         self._tmpdir = mkdtemp(dir=tmproot, prefix="metaflow.s3.")
-        self._encryption = encryption
+        self._settings = settings
 
     def __enter__(self) -> "S3":
         return self

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -475,6 +475,16 @@ class S3(object):
     s3root : str, optional
         If `run` is not specified, use this as the S3 prefix.
     """
+    @classmethod  # check this decorator
+    def parse_s3_custom_settings(settings_str: Optional[str]):
+        s3_settings = {}
+        for setting in settings_str.split(","):
+            setting = setting.strip()
+            if setting:
+                key, value = setting.split("=")
+                s3_settings[key.strip()] = value.strip()
+        return s3_settings
+
 
     @classmethod
     def get_root_from_config(cls, echo, create_on_absent=True):

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -356,12 +356,12 @@ class S3Object(object):
     @property
     def encryption(self) -> Optional[str]:
         """
-        Returns the server-side-encryption the S3 object or None if it is not defined.
+        Returns the encryption type of the S3 object or None if it is not defined.
 
         Returns
         -------
         str
-            Server-side-encryption or None if server side encryption is not specified through s3 upload args.
+            Server-side-encryption type or None if server side encryption is not specified through s3 upload args.
         """
         return self._encryption
 

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -1221,8 +1221,6 @@ class S3(object):
                     }
                 if self._upload_args:
                     upload_args = self._upload_args
-                    if "ServerSideEncryption" in upload_args:
-                        upload_args["encryption"] = upload_args["ServerSideEncryption"]
                     store_info.update(upload_args)
                 if isinstance(obj, (RawIOBase, BufferedIOBase)):
                     if not obj.readable() or not obj.seekable():
@@ -1298,8 +1296,6 @@ class S3(object):
                     }
                 if self._upload_args:
                     upload_args = self._upload_args
-                    if "ServerSideEncryption" in upload_args:
-                        upload_args["encryption"] = upload_args["ServerSideEncryption"]
                     store_info.update(upload_args)
                 if not os.path.exists(path):
                     raise MetaflowS3NotFound("Local file not found: %s" % path)

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -86,7 +86,7 @@ S3PutObject = namedtuple_with_defaults(
         ("content_type", Optional[str]),
         ("metadata", Optional[Dict[str, str]]),
     ],
-    defaults=(None, None, None, None,),
+    defaults=(None, None, None, None),
 )
 S3PutObject.__module__ = __name__
 
@@ -475,15 +475,6 @@ class S3(object):
     s3root : str, optional
         If `run` is not specified, use this as the S3 prefix.
     """
-    @classmethod
-    def parse_custom_s3_settings(self, settings_str: Optional[str]):
-        s3_settings = {}
-        for setting in settings_str.split(","):
-            setting = setting.strip()
-            if setting:
-                key, value = setting.split("=")
-                s3_settings[key.strip()] = value.strip()
-        return s3_settings
 
     @classmethod
     def get_root_from_config(cls, echo, create_on_absent=True):
@@ -496,7 +487,7 @@ class S3(object):
         prefix: Optional[str] = None,
         run: Optional[Union[FlowSpec, "Run"]] = None,
         s3root: Optional[str] = None,
-        upload_settings: Optional[str] = S3_CUSTOM_UPLOAD_SETTINGS,
+        upload_settings: Optional[dict] = S3_CUSTOM_UPLOAD_SETTINGS,
         **kwargs
     ):
         if not boto_found:
@@ -1141,7 +1132,6 @@ class S3(object):
                     "metaflow-user-attributes": json.dumps(metadata)
                 }
             if self._upload_settings:
-                #upload_settings = self.parse_custom_s3_settings(self._upload_settings)
                 upload_settings = self._upload_settings
                 extra_args.update(upload_settings)
 
@@ -1217,7 +1207,6 @@ class S3(object):
                         "metaflow-user-attributes": json.dumps(metadata)
                     }
                 if self._upload_settings:
-                    #upload_settings = self.parse_custom_s3_settings(self._upload_settings)
                     upload_settings = self._upload_settings
                     store_info.update(upload_settings)
                 if isinstance(obj, (RawIOBase, BufferedIOBase)):
@@ -1294,7 +1283,6 @@ class S3(object):
                     }
                 if self._upload_settings:
                     upload_settings = self._upload_settings
-                    #upload_settings = self.parse_custom_s3_settings(self._upload_settings)
                     store_info.update(upload_settings)
                 if not os.path.exists(path):
                     raise MetaflowS3NotFound("Local file not found: %s" % path)

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -1132,7 +1132,7 @@ class S3(object):
         url = self._url(key)
         src = urlparse(url)
         extra_args = None
-        if content_type or metadata or self._encryption:
+        if content_type or metadata or self._settings:
             extra_args = {}
             if content_type:
                 extra_args["ContentType"] = content_type
@@ -1140,8 +1140,9 @@ class S3(object):
                 extra_args["Metadata"] = {
                     "metaflow-user-attributes": json.dumps(metadata)
                 }
-            if self._encryption:
-                extra_args['ServerSideEncryption'] = self._encryption
+            if self._settings:
+                upload_settings = self.parse_custom_s3_settings(self._settings)
+                extra_args.update(upload_settings)
 
         def _upload(s3, _):
             # We make sure we are at the beginning in case we are retrying
@@ -1214,8 +1215,9 @@ class S3(object):
                     store_info["metadata"] = {
                         "metaflow-user-attributes": json.dumps(metadata)
                     }
-                if self._encryption:
-                    store_info['ServerSideEncryption'] = self._encryption
+                if self._settings:
+                    upload_settings = self.parse_custom_s3_settings(self._settings)
+                    store_info.update(upload_settings)
                 if isinstance(obj, (RawIOBase, BufferedIOBase)):
                     if not obj.readable() or not obj.seekable():
                         raise MetaflowS3InvalidObject(
@@ -1288,8 +1290,9 @@ class S3(object):
                     store_info["metadata"] = {
                         "metaflow-user-attributes": json.dumps(metadata)
                     }
-                if self._encryption:
-                    store_info['ServerSideEncryption'] = self._encryption
+                if self._settings:
+                    upload_settings = self.parse_custom_s3_settings(self._settings)
+                    store_info.update(upload_settings)
                 if not os.path.exists(path):
                     raise MetaflowS3NotFound("Local file not found: %s" % path)
                 yield path, self._url(key), store_info

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -831,8 +831,9 @@ class S3(object):
                         else:
                             raise MetaflowS3Exception("Got error: %d" % info["error"])
                     else:
-                        yield self._s3root, s3url, None, info["size"], info["content_type"],
-                        info["metadata"], None, info["last_modified"], info["encryption"]
+                        yield self._s3root, s3url, None, info["size"], \
+                        info["content_type"], info["metadata"], None, \
+                        info["last_modified"], info["encryption"]
                 else:
                     # This should not happen; we should always get a response
                     # even if it contains an error inside it
@@ -990,8 +991,9 @@ class S3(object):
                                 - range_info["start"]
                                 + 1,
                             )
-                        yield self._s3root, s3url, os.path.join(self._tmpdir, fname),
-                        None, info["content_type"], info[ "metadata"], range_info, info["last_modified"], info["encryption"]
+                            yield self._s3root, s3url, os.path.join(self._tmpdir, fname ), \
+                                None, info["content_type"], info["metadata"], \
+                                range_info, info["last_modified"], info["encryption"]
                     else:
                         yield self._s3root, s3prefix, None
                 else:
@@ -1046,8 +1048,8 @@ class S3(object):
                             request_offset=range_info["start"],
                             request_length=range_info["end"] - range_info["start"] + 1,
                         )
-                    yield self._s3root, s3url, os.path.join(self._tmpdir, fname),
-                    None, info["content_type"], info["metadata"], range_info,
+                    yield self._s3root, s3url, os.path.join(self._tmpdir, fname), \
+                    None, info["content_type"], info["metadata"], range_info, \
                     info["last_modified"], info["encryption"]
                 else:
                     yield s3prefix, s3url, os.path.join(self._tmpdir, fname)

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -831,8 +831,8 @@ class S3(object):
                         else:
                             raise MetaflowS3Exception("Got error: %d" % info["error"])
                     else:
-                        yield self._s3root, s3url, None, info["size"], info["content_type"
-                        ], info["metadata"], None, info["last_modified"], info["encryption"]
+                        yield self._s3root, s3url, None, info["size"], info["content_type"],
+                        info["metadata"], None, info["last_modified"], info["encryption"]
                 else:
                     # This should not happen; we should always get a response
                     # even if it contains an error inside it
@@ -990,8 +990,8 @@ class S3(object):
                                 - range_info["start"]
                                 + 1,
                             )
-                        yield self._s3root, s3url, os.path.join(
-                            self._tmpdir, fname), None, info["content_type"], info[ "metadata"], range_info, info["last_modified"], info["encryption"]
+                        yield self._s3root, s3url, os.path.join(self._tmpdir, fname),
+                        None, info["content_type"], info[ "metadata"], range_info, info["last_modified"], info["encryption"]
                     else:
                         yield self._s3root, s3prefix, None
                 else:
@@ -1046,9 +1046,9 @@ class S3(object):
                             request_offset=range_info["start"],
                             request_length=range_info["end"] - range_info["start"] + 1,
                         )
-                    yield self._s3root, s3url, os.path.join(
-                        self._tmpdir, fname
-                    ), None, info["content_type"], info["metadata"], range_info, info["last_modified"], info["encryption"]
+                    yield self._s3root, s3url, os.path.join(self._tmpdir, fname),
+                    None, info["content_type"], info["metadata"], range_info,
+                    info["last_modified"], info["encryption"]
                 else:
                     yield s3prefix, s3url, os.path.join(self._tmpdir, fname)
         return list(starmap(S3Object, _get()))

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -991,8 +991,7 @@ class S3(object):
                                 + 1,
                             )
                         yield self._s3root, s3url, os.path.join(
-                            self._tmpdir, fname), None, info["content_type"], info[ "metadata"], 
-                        range_info, info["last_modified"], info["encryption"]
+                            self._tmpdir, fname), None, info["content_type"], info[ "metadata"], range_info, info["last_modified"], info["encryption"]
                     else:
                         yield self._s3root, s3prefix, None
                 else:
@@ -1001,7 +1000,6 @@ class S3(object):
                     else:
                         # missing entries per return_missing=True
                         yield self._s3root, s3prefix, None
-
         return list(starmap(S3Object, _get()))
 
     def get_recursive(
@@ -1050,11 +1048,9 @@ class S3(object):
                         )
                     yield self._s3root, s3url, os.path.join(
                         self._tmpdir, fname
-                    ), None, info["content_type"], info["metadata"], range_info, 
-                    info["last_modified"], info["encryption"]
+                    ), None, info["content_type"], info["metadata"], range_info, info["last_modified"], info["encryption"]
                 else:
                     yield s3prefix, s3url, os.path.join(self._tmpdir, fname)
-
         return list(starmap(S3Object, _get()))
 
     def get_all(self, return_info: bool = False) -> List[S3Object]:

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -1169,7 +1169,7 @@ class S3(object):
         else:
 
             def _head(s3, _):
-                s3.head_object(Bucket=src.netloc, Key=src.path.lstrip("/"), ExtraArgs=extra_args)
+                s3.head_object(Bucket=src.netloc, Key=src.path.lstrip("/"))
 
             try:
                 self._one_boto_op(_head, url, create_tmp_file=False)

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -352,19 +352,6 @@ class S3Object(object):
             Content type or None if the content type is undefined.
         """
         return self._content_type
-    
-    @property
-    def upload_args(self) -> Optional[str]:
-        """
-        Returns the upload arguments of the S3 object or None if it is not defined.
-
-        Returns
-        -------
-        str
-            Upload args or None if the content type is undefined.
-        """
-        return self._upload_args
-
 
     @property
     def range_info(self) -> Optional[RangeInfo]:
@@ -753,7 +740,7 @@ class S3(object):
         src = urlparse(url)
 
         def _info(s3, tmp):
-            resp = s3.head_object(Bucket=src.netloc, Key=src.path.lstrip('/"')) # what exactly does head object return
+            resp = s3.head_object(Bucket=src.netloc, Key=src.path.lstrip('/"'))
             return {
                 "content_type": resp["ContentType"],
                 "encryption": resp["ServerSideEncryption"],
@@ -893,7 +880,7 @@ class S3(object):
                     + 1,
                 )
             else:
-                resp = s3.get_object(Bucket=src.netloc, Key=src.path.lstrip("/")) # what does get object return?
+                resp = s3.get_object(Bucket=src.netloc, Key=src.path.lstrip("/"))
                 range_result = None
             sz = resp["ContentLength"]
             if range_result is None:

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -86,7 +86,7 @@ S3PutObject = namedtuple_with_defaults(
         ("content_type", Optional[str]),
         ("metadata", Optional[Dict[str, str]]),
     ],
-    defaults=(None, None, None, None),
+    defaults=(None, None, None, None,),
 )
 S3PutObject.__module__ = __name__
 
@@ -496,7 +496,7 @@ class S3(object):
         prefix: Optional[str] = None,
         run: Optional[Union[FlowSpec, "Run"]] = None,
         s3root: Optional[str] = None,
-        settings: Optional[str] = S3_CUSTOM_UPLOAD_SETTINGS,
+        upload_settings: Optional[str] = S3_CUSTOM_UPLOAD_SETTINGS,
         **kwargs
     ):
         if not boto_found:
@@ -550,7 +550,7 @@ class S3(object):
             "inject_failure_rate", TEST_INJECT_RETRYABLE_FAILURES
         )
         self._tmpdir = mkdtemp(dir=tmproot, prefix="metaflow.s3.")
-        self._settings = settings
+        self._upload_settings = upload_settings
 
     def __enter__(self) -> "S3":
         return self
@@ -1132,7 +1132,7 @@ class S3(object):
         url = self._url(key)
         src = urlparse(url)
         extra_args = None
-        if content_type or metadata or self._settings:
+        if content_type or metadata or self._upload_settings:
             extra_args = {}
             if content_type:
                 extra_args["ContentType"] = content_type
@@ -1140,8 +1140,9 @@ class S3(object):
                 extra_args["Metadata"] = {
                     "metaflow-user-attributes": json.dumps(metadata)
                 }
-            if self._settings:
-                upload_settings = self.parse_custom_s3_settings(self._settings)
+            if self._upload_settings:
+                #upload_settings = self.parse_custom_s3_settings(self._upload_settings)
+                upload_settings = self._upload_settings
                 extra_args.update(upload_settings)
 
         def _upload(s3, _):
@@ -1215,8 +1216,9 @@ class S3(object):
                     store_info["metadata"] = {
                         "metaflow-user-attributes": json.dumps(metadata)
                     }
-                if self._settings:
-                    upload_settings = self.parse_custom_s3_settings(self._settings)
+                if self._upload_settings:
+                    #upload_settings = self.parse_custom_s3_settings(self._upload_settings)
+                    upload_settings = self._upload_settings
                     store_info.update(upload_settings)
                 if isinstance(obj, (RawIOBase, BufferedIOBase)):
                     if not obj.readable() or not obj.seekable():
@@ -1290,8 +1292,9 @@ class S3(object):
                     store_info["metadata"] = {
                         "metaflow-user-attributes": json.dumps(metadata)
                     }
-                if self._settings:
-                    upload_settings = self.parse_custom_s3_settings(self._settings)
+                if self._upload_settings:
+                    upload_settings = self._upload_settings
+                    #upload_settings = self.parse_custom_s3_settings(self._upload_settings)
                     store_info.update(upload_settings)
                 if not os.path.exists(path):
                     raise MetaflowS3NotFound("Local file not found: %s" % path)

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -352,6 +352,18 @@ class S3Object(object):
             Content type or None if the content type is undefined.
         """
         return self._content_type
+    
+    @property
+    def encryption(self) -> Optional[str]:
+        """
+        Returns the server-side-encryption the S3 object or None if it is not defined.
+
+        Returns
+        -------
+        str
+            Server-side-encryption or None if the content type is undefined.
+        """
+        return self._encryption
 
     @property
     def range_info(self) -> Optional[RangeInfo]:

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -476,7 +476,7 @@ class S3(object):
         If `run` is not specified, use this as the S3 prefix.
     """
     @classmethod  # check this decorator
-    def parse_custom_s3_settings(settings_str: Optional[str]):
+    def parse_custom_s3_settings(self, settings_str: Optional[str]):
         s3_settings = {}
         for setting in settings_str.split(","):
             setting = setting.strip()

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -1228,6 +1228,8 @@ class S3(object):
                     }
                 if self._upload_args:
                     upload_args = self._upload_args
+                    if "ServerSideEncryption" in upload_args:
+                        store_info["encryption"] = upload_args["ServerSideEncryption"]
                     store_info.update(upload_args)
                 if isinstance(obj, (RawIOBase, BufferedIOBase)):
                     if not obj.readable() or not obj.seekable():

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -361,7 +361,7 @@ class S3Object(object):
         Returns
         -------
         str
-            Server-side-encryption or None if the content type is undefined.
+            Server-side-encryption or None if server side encryption is not specified through s3 upload args.
         """
         return self._encryption
 
@@ -759,7 +759,6 @@ class S3(object):
                 "metadata": resp["Metadata"],
                 "size": resp["ContentLength"],
                 "last_modified": get_timestamp(resp["LastModified"]),
-                # upload args?
             }
 
         info_results = None

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -178,7 +178,7 @@ class S3Object(object):
         else:
             self._key = url[len(prefix.rstrip("/")) + 1 :].rstrip("/")
             self._prefix = prefix
-        
+
         self._encryption = encryption
 
     @property
@@ -353,7 +353,7 @@ class S3Object(object):
             Content type or None if the content type is undefined.
         """
         return self._content_type
-    
+
     @property
     def encryption(self) -> Optional[str]:
         """
@@ -759,7 +759,7 @@ class S3(object):
                 "metadata": resp["Metadata"],
                 "size": resp["ContentLength"],
                 "last_modified": get_timestamp(resp["LastModified"]),
-                "encryption": resp["ServerSideEncryption"]
+                "encryption": resp["ServerSideEncryption"],
             }
 
         info_results = None
@@ -779,7 +779,7 @@ class S3(object):
                 content_type=info_results["content_type"],
                 metadata=info_results["metadata"],
                 last_modified=info_results["last_modified"],
-                encryption=info_results["encryption"]
+                encryption=info_results["encryption"],
             )
         return S3Object(self._s3root, url, None)
 
@@ -831,9 +831,11 @@ class S3(object):
                         else:
                             raise MetaflowS3Exception("Got error: %d" % info["error"])
                     else:
-                        yield self._s3root, s3url, None, info["size"], \
-                        info["content_type"], info["metadata"], None, \
-                        info["last_modified"], info["encryption"]
+                        yield self._s3root, s3url, None, info["size"], info[
+                            "content_type"
+                        ], info["metadata"], None, info["last_modified"], info[
+                            "encryption"
+                        ]
                 else:
                     # This should not happen; we should always get a response
                     # even if it contains an error inside it
@@ -991,9 +993,15 @@ class S3(object):
                                 - range_info["start"]
                                 + 1,
                             )
-                            yield self._s3root, s3url, os.path.join(self._tmpdir, fname ), \
-                                None, info["content_type"], info["metadata"], \
-                                range_info, info["last_modified"], info["encryption"]
+                            yield self._s3root, s3url, os.path.join(
+                                self._tmpdir, fname
+                            ), None, info["content_type"], info[
+                                "metadata"
+                            ], range_info, info[
+                                "last_modified"
+                            ], info[
+                                "encryption"
+                            ]
                     else:
                         yield self._s3root, s3prefix, None
                 else:
@@ -1002,6 +1010,7 @@ class S3(object):
                     else:
                         # missing entries per return_missing=True
                         yield self._s3root, s3prefix, None
+
         return list(starmap(S3Object, _get()))
 
     def get_recursive(
@@ -1048,11 +1057,16 @@ class S3(object):
                             request_offset=range_info["start"],
                             request_length=range_info["end"] - range_info["start"] + 1,
                         )
-                    yield self._s3root, s3url, os.path.join(self._tmpdir, fname), \
-                    None, info["content_type"], info["metadata"], range_info, \
-                    info["last_modified"], info["encryption"]
+                    yield self._s3root, s3url, os.path.join(
+                        self._tmpdir, fname
+                    ), None, info["content_type"], info["metadata"], range_info, info[
+                        "last_modified"
+                    ], info[
+                        "encryption"
+                    ]
                 else:
                     yield s3prefix, s3url, os.path.join(self._tmpdir, fname)
+
         return list(starmap(S3Object, _get()))
 
     def get_all(self, return_info: bool = False) -> List[S3Object]:

--- a/metaflow/plugins/datatools/s3/s3.py
+++ b/metaflow/plugins/datatools/s3/s3.py
@@ -475,7 +475,7 @@ class S3(object):
     s3root : str, optional
         If `run` is not specified, use this as the S3 prefix.
     """
-    @classmethod  # check this decorator
+    @classmethod
     def parse_custom_s3_settings(self, settings_str: Optional[str]):
         s3_settings = {}
         for setting in settings_str.split(","):

--- a/metaflow/plugins/datatools/s3/s3op.py
+++ b/metaflow/plugins/datatools/s3/s3op.py
@@ -845,7 +845,7 @@ def put(
                 local = r["local"]
                 url = r["url"]
                 content_type = r.get("content_type", None)
-                upload_args = {k: v for k, v in r.items() if k not in ["local", "url", "content_type", "metadata", "idx", "key", "encryption"]}
+                upload_args = {k: v for k, v in r.items() if k not in ["local", "url", "content_type", "metadata", "idx", "key"]}
                 metadata = r.get("metadata", None)
                 if not os.path.exists(local):
                     exit(ERROR_LOCAL_FILE_NOT_FOUND, local)

--- a/metaflow/plugins/datatools/s3/s3op.py
+++ b/metaflow/plugins/datatools/s3/s3op.py
@@ -78,7 +78,7 @@ class S3Url(object):
         self.metadata = metadata
         self.range = range
         self.idx = idx
-        self.upload_args=upload_args
+        self.upload_args = upload_args
 
     def __str__(self):
         return self.url
@@ -845,7 +845,12 @@ def put(
                 local = r["local"]
                 url = r["url"]
                 content_type = r.get("content_type", None)
-                upload_args = {k: v for k, v in r.items() if k not in ["local", "url", "content_type", "metadata", "idx", "key"]}
+                upload_args = {
+                    k: v
+                    for k, v in r.items()
+                    if k
+                    not in ["local", "url", "content_type", "metadata", "idx", "key"]
+                }
                 metadata = r.get("metadata", None)
                 if not os.path.exists(local):
                     exit(ERROR_LOCAL_FILE_NOT_FOUND, local)
@@ -862,7 +867,7 @@ def put(
             content_type=content_type,
             metadata=metadata,
             idx=idx,
-            upload_args=upload_args
+            upload_args=upload_args,
         )
         if src.scheme != "s3":
             exit(ERROR_INVALID_URL, url)

--- a/metaflow/plugins/datatools/s3/s3op.py
+++ b/metaflow/plugins/datatools/s3/s3op.py
@@ -280,7 +280,7 @@ def worker(result_file_name, queue, mode, s3config):
                             if resp["Metadata"] is not None:
                                 args["metadata"] = resp["Metadata"]
                             if resp["ServerSideEncryption"] is not None:
-                                args["encryptoin"] = resp["ServerSideEncryption"]
+                                args["encryption"] = resp["ServerSideEncryption"]
                             if resp["LastModified"]:
                                 args["last_modified"] = get_timestamp(
                                     resp["LastModified"]

--- a/metaflow/plugins/datatools/s3/s3op.py
+++ b/metaflow/plugins/datatools/s3/s3op.py
@@ -75,8 +75,8 @@ class S3Url(object):
         self.local = local
         self.prefix = prefix
         self.content_type = content_type
-        self.metadata = metadata,
-        self.encryption=encryption,
+        self.metadata = metadata
+        self.encryption=encryption
         self.range = range
         self.idx = idx
 

--- a/test/data/s3/s3_data.py
+++ b/test/data/s3/s3_data.py
@@ -516,8 +516,9 @@ def ensure_test_data():
                     # (since it is the same) but we modify the path to post-pend
                     # the name
                     print("Test data case %s: upload to %s started" % (prefix, f.url))
+                    extra = {"ServerSideEncryption": "AES256"}
                     s3client.upload_fileobj(
-                        f.fileobj(), url.netloc, url.path.lstrip("/"), ServerSideEncryption="AES256"
+                        f.fileobj(), url.netloc, url.path.lstrip("/"), ExtraArgs=extra
                     )
                     print("Test data case %s: uploaded to %s" % (prefix, f.url))
                     if meta is not None:
@@ -552,8 +553,9 @@ def ensure_test_data():
         for prefix, filespecs in BASIC_DATA:
             _do_upload(prefix, filespecs, meta=BASIC_METADATA)
 
+        extra = {"ServerSideEncryption": "AES256"}
         s3client.upload_fileobj(
-            to_fileobj("ok"), Bucket=mark.netloc, Key=mark.path.lstrip("/"), ServerSideEncryption="AES256"
+            to_fileobj("ok"), Bucket=mark.netloc, Key=mark.path.lstrip("/"), ExtraArgs=extra
         )
         print("Test data uploaded ok")
 

--- a/test/data/s3/s3_data.py
+++ b/test/data/s3/s3_data.py
@@ -507,7 +507,7 @@ def ensure_test_data():
     except:
         print("Uploading test data")
 
-        def _do_upload(prefix, filespecs, meta=None):
+        def _do_upload(prefix, filespecs, meta=None): # NEED TO ADD SSE ENCRYPTION HERE TO TEST LOCALLY
             for fname, size in filespecs.items():
                 if size is not None:
                     f = RandomFile(prefix, fname, size)
@@ -517,7 +517,7 @@ def ensure_test_data():
                     # the name
                     print("Test data case %s: upload to %s started" % (prefix, f.url))
                     s3client.upload_fileobj(
-                        f.fileobj(), url.netloc, url.path.lstrip("/")
+                        f.fileobj(), url.netloc, url.path.lstrip("/"), ServerSideEncryption="AES256"
                     )
                     print("Test data case %s: uploaded to %s" % (prefix, f.url))
                     if meta is not None:
@@ -528,7 +528,7 @@ def ensure_test_data():
                                 "Test data case %s: upload to %s started"
                                 % (prefix, new_url)
                             )
-                            extra = {}
+                            extra = {"ServerSideEncryption": "AES256"}
                             content_type, user_meta = metainfo
                             if content_type:
                                 extra["ContentType"] = content_type
@@ -553,7 +553,7 @@ def ensure_test_data():
             _do_upload(prefix, filespecs, meta=BASIC_METADATA)
 
         s3client.upload_fileobj(
-            to_fileobj("ok"), Bucket=mark.netloc, Key=mark.path.lstrip("/")
+            to_fileobj("ok"), Bucket=mark.netloc, Key=mark.path.lstrip("/"), ServerSideEncryption="AES256"
         )
         print("Test data uploaded ok")
 

--- a/test/data/s3/test_s3.py
+++ b/test/data/s3/test_s3.py
@@ -887,7 +887,7 @@ def test_put_files(tempdir, inject_failure_rate, s3root, blobs, expected, s3_upl
             yield S3PutObject(
                 key=key, value=path, content_type=content_type, metadata=metadata, encryption=encryption
             )
-    upload_args = [s3_upload_args ,None]
+    upload_args = [s3_upload_args, None]
     for args in upload_args:
         with S3(s3root=s3root, inject_failure_rate=inject_failure_rate, upload_args=args) as s3:
             s3urls = s3.put_files(_files(blobs))

--- a/test/data/s3/test_s3.py
+++ b/test/data/s3/test_s3.py
@@ -146,7 +146,7 @@ def assert_results(
                     )
                 # if upload arguments are OK - this is not a comprehensive list
                 if upload_args: 
-                    assert s3obj.ServerSideEncryption == upload_args.get('ServerSideEncryption')
+                    assert s3obj.encryption == upload_args.get('ServerSideEncryption')
 
 
 def shuffle(objs):

--- a/test/data/s3/test_s3.py
+++ b/test/data/s3/test_s3.py
@@ -847,24 +847,24 @@ def s3_upload_args():
 @pytest.mark.parametrize(
     argnames=["s3root", "objs", "expected"], **s3_data.pytest_put_strings_case()
 )
-def test_put_one(s3root, objs, expected):
-    upload_args_list = [None, s3_upload_args()]
-    for upload_args in upload_args_list:
-        with S3(s3root=s3root, upload_args=upload_args) as s3:
-            for key, obj in objs:
-                s3url = s3.put(key, obj)
-                assert s3url in expected
-                s3obj = s3.get(key)
-                assert s3obj.key == key
-                assert_results([s3obj], {s3url: expected[s3url]}, upload_args=upload_args)
-                assert s3obj.blob == to_bytes(obj)
-                # put with overwrite disabled
-                s3url = s3.put(key, "random_value", overwrite=False)
-                assert s3url in expected
-                s3obj = s3.get(key)
-                assert s3obj.key == key
-                assert_results([s3obj], {s3url: expected[s3url]}, upload_args=upload_args)
-                assert s3obj.blob == to_bytes(obj)
+def test_put_one(s3root, objs, expected, s3_upload_args):
+        upload_args = [s3_upload_args, None]
+        for args in upload_args:
+            with S3(s3root=s3root, upload_args=args) as s3:
+                for key, obj in objs:
+                    s3url = s3.put(key, obj)
+                    assert s3url in expected
+                    s3obj = s3.get(key)
+                    assert s3obj.key == key
+                    assert_results([s3obj], {s3url: expected[s3url]}, upload_args=args)
+                    assert s3obj.blob == to_bytes(obj)
+                    # put with overwrite disabled
+                    s3url = s3.put(key, "random_value", overwrite=False)
+                    assert s3url in expected
+                    s3obj = s3.get(key)
+                    assert s3obj.key == key
+                    assert_results([s3obj], {s3url: expected[s3url]}, upload_args=args)
+                    assert s3obj.blob == to_bytes(obj)
 
 
 @pytest.mark.parametrize("inject_failure_rate", [0, 10, 50, 90])

--- a/test/data/s3/test_s3.py
+++ b/test/data/s3/test_s3.py
@@ -41,8 +41,12 @@ def s3_get_object_from_url_range(url, range_info):
 
 
 def assert_results(
-    s3objs, expected, upload_args=None, info_should_be_empty=False,
-    info_only=False, ranges_fetched=None
+    s3objs,
+    expected,
+    upload_args=None,
+    info_should_be_empty=False,
+    info_only=False,
+    ranges_fetched=None,
 ):
     # did we receive all expected objects and nothing else?
     if info_only:
@@ -147,7 +151,7 @@ def assert_results(
                     )
                 # if upload arguments are OK - this is not a comprehensive list
                 if upload_args:
-                    assert s3obj.encryption == upload_args.get('ServerSideEncryption')
+                    assert s3obj.encryption == upload_args.get("ServerSideEncryption")
 
 
 def shuffle(objs):
@@ -787,7 +791,7 @@ def test_get_recursive(inject_failure_rate, s3root, prefixes, expected):
         if len(prefixes) == 1:
             [prefix] = prefixes
             s3root = os.path.join(s3root, prefix)
-            keys = {url[len(s3root) + 1:] for url in expected_exists}
+            keys = {url[len(s3root) + 1 :] for url in expected_exists}
             assert {e.key for e in s3objs} == keys
 
         local_files = [s3obj.path for s3obj in s3objs]
@@ -812,9 +816,9 @@ def test_put_exceptions(inject_failure_rate):
 @pytest.fixture
 def s3_upload_args():
     return {
-        'ServerSideEncryption': 'AES256',
-        'ACL': 'private',
-        'StorageClass': 'STANDARD_IA',
+        "ServerSideEncryption": "AES256",
+        "ACL": "private",
+        "StorageClass": "STANDARD_IA",
     }
 
 
@@ -825,7 +829,9 @@ def s3_upload_args():
 def test_put_many(inject_failure_rate, s3root, objs, expected, s3_upload_args):
     upload_args = [s3_upload_args, None]
     for args in upload_args:
-        with S3(s3root=s3root, inject_failure_rate=inject_failure_rate, upload_args=args) as s3:
+        with S3(
+            s3root=s3root, inject_failure_rate=inject_failure_rate, upload_args=args
+        ) as s3:
             s3urls = s3.put_many(objs)
             assert list(dict(s3urls)) == list(dict(objs))
             # results must be in the same order as the keys requested
@@ -834,13 +840,17 @@ def test_put_many(inject_failure_rate, s3root, objs, expected, s3_upload_args):
         with S3(inject_failure_rate=inject_failure_rate, upload_args=args) as s3:
             s3objs = s3.get_many(dict(s3urls).values())
             assert_results(s3objs, expected, upload_args=args)
-        with S3(s3root=s3root, inject_failure_rate=inject_failure_rate, upload_args=args) as s3:
+        with S3(
+            s3root=s3root, inject_failure_rate=inject_failure_rate, upload_args=args
+        ) as s3:
             s3objs = s3.get_many(list(dict(objs)))
             assert {s3obj.key for s3obj in s3objs} == {key for key, _ in objs}
 
         # upload shuffled objs with overwrite disabled
         shuffled_objs = deranged_shuffle(objs)
-        with S3(s3root=s3root, inject_failure_rate=inject_failure_rate, upload_args=args) as s3:
+        with S3(
+            s3root=s3root, inject_failure_rate=inject_failure_rate, upload_args=args
+        ) as s3:
             overwrite_disabled_s3urls = s3.put_many(shuffled_objs, overwrite=False)
             assert len(overwrite_disabled_s3urls) == 0
         with S3(inject_failure_rate=inject_failure_rate, upload_args=args) as s3:
@@ -875,7 +885,9 @@ def test_put_one(s3root, objs, expected, s3_upload_args):
 @pytest.mark.parametrize(
     argnames=["s3root", "blobs", "expected"], **s3_data.pytest_put_blobs_case()
 )
-def test_put_files(tempdir, inject_failure_rate, s3root, blobs, expected, s3_upload_args):
+def test_put_files(
+    tempdir, inject_failure_rate, s3root, blobs, expected, s3_upload_args
+):
     def _files(blobs):
         for blob in blobs:
             key = getattr(blob, "key", blob[0])
@@ -887,11 +899,18 @@ def test_put_files(tempdir, inject_failure_rate, s3root, blobs, expected, s3_upl
             with open(path, "wb") as f:
                 f.write(data)
             yield S3PutObject(
-                key=key, value=path, content_type=content_type, metadata=metadata, encryption=encryption
+                key=key,
+                value=path,
+                content_type=content_type,
+                metadata=metadata,
+                encryption=encryption,
             )
+
     upload_args = [s3_upload_args, None]
     for args in upload_args:
-        with S3(s3root=s3root, inject_failure_rate=inject_failure_rate, upload_args=args) as s3:
+        with S3(
+            s3root=s3root, inject_failure_rate=inject_failure_rate, upload_args=args
+        ) as s3:
             s3urls = s3.put_files(_files(blobs))
             assert list(dict(s3urls)) == list(dict(blobs))
 
@@ -900,7 +919,9 @@ def test_put_files(tempdir, inject_failure_rate, s3root, blobs, expected, s3_upl
             s3objs = s3.get_many(dict(s3urls).values())
             assert_results(s3objs, expected, upload_args=args)
 
-        with S3(s3root=s3root, inject_failure_rate=inject_failure_rate, upload_args=args) as s3:
+        with S3(
+            s3root=s3root, inject_failure_rate=inject_failure_rate, upload_args=args
+        ) as s3:
             # get keys
             s3objs = s3.get_many(key for key, blob in blobs)
             assert {s3obj.key for s3obj in s3objs} == {key for key, _ in blobs}
@@ -908,7 +929,9 @@ def test_put_files(tempdir, inject_failure_rate, s3root, blobs, expected, s3_upl
         # upload shuffled blobs with overwrite disabled
         shuffled_blobs = blobs[:]
         shuffle(shuffled_blobs)
-        with S3(s3root=s3root, inject_failure_rate=inject_failure_rate, upload_args=args) as s3:
+        with S3(
+            s3root=s3root, inject_failure_rate=inject_failure_rate, upload_args=args
+        ) as s3:
             overwrite_disabled_s3urls = s3.put_files(
                 _files(shuffled_blobs), overwrite=False
             )
@@ -917,6 +940,8 @@ def test_put_files(tempdir, inject_failure_rate, s3root, blobs, expected, s3_upl
         with S3(inject_failure_rate=inject_failure_rate, upload_args=args) as s3:
             s3objs = s3.get_many(dict(s3urls).values())
             assert_results(s3objs, expected, upload_args=args)
-        with S3(s3root=s3root, inject_failure_rate=inject_failure_rate, upload_args=args) as s3:
+        with S3(
+            s3root=s3root, inject_failure_rate=inject_failure_rate, upload_args=args
+        ) as s3:
             s3objs = s3.get_many(key for key, blob in shuffled_blobs)
             assert {s3obj.key for s3obj in s3objs} == {key for key, _ in shuffled_blobs}

--- a/test/data/s3/test_s3.py
+++ b/test/data/s3/test_s3.py
@@ -147,8 +147,6 @@ def assert_results(
                 # if upload arguments are OK - this is not a comprehensive list
                 if upload_args: 
                     assert s3obj.ServerSideEncryption == upload_args.get('ServerSideEncryption')
-                    assert s3obj.ACL == upload_args.get('ACL')
-                    assert s3obj.StorageClass == upload_args.get('StorageClass') 
 
 
 def shuffle(objs):

--- a/test/data/s3/test_s3.py
+++ b/test/data/s3/test_s3.py
@@ -41,7 +41,8 @@ def s3_get_object_from_url_range(url, range_info):
 
 
 def assert_results(
-    s3objs, expected, upload_args=None, info_should_be_empty=False, info_only=False, ranges_fetched=None
+    s3objs, expected, upload_args=None, info_should_be_empty=False,
+    info_only=False, ranges_fetched=None
 ):
     # did we receive all expected objects and nothing else?
     if info_only:
@@ -145,7 +146,7 @@ def assert_results(
                         extra_keys
                     )
                 # if upload arguments are OK - this is not a comprehensive list
-                if upload_args: 
+                if upload_args:
                     assert s3obj.encryption == upload_args.get('ServerSideEncryption')
 
 
@@ -786,7 +787,7 @@ def test_get_recursive(inject_failure_rate, s3root, prefixes, expected):
         if len(prefixes) == 1:
             [prefix] = prefixes
             s3root = os.path.join(s3root, prefix)
-            keys = {url[len(s3root) + 1 :] for url in expected_exists}
+            keys = {url[len(s3root) + 1:] for url in expected_exists}
             assert {e.key for e in s3objs} == keys
 
         local_files = [s3obj.path for s3obj in s3objs]
@@ -812,9 +813,10 @@ def test_put_exceptions(inject_failure_rate):
 def s3_upload_args():
     return {
         'ServerSideEncryption': 'AES256',
-        'ACL': 'private', 
-        'StorageClass': 'STANDARD_IA'
+        'ACL': 'private',
+        'StorageClass': 'STANDARD_IA',
     }
+
 
 @pytest.mark.parametrize("inject_failure_rate", [0, 10, 50, 90])
 @pytest.mark.parametrize(
@@ -850,23 +852,23 @@ def test_put_many(inject_failure_rate, s3root, objs, expected, s3_upload_args):
     argnames=["s3root", "objs", "expected"], **s3_data.pytest_put_strings_case()
 )
 def test_put_one(s3root, objs, expected, s3_upload_args):
-        upload_args = [s3_upload_args, None]
-        for args in upload_args:
-            with S3(s3root=s3root, upload_args=args) as s3:
-                for key, obj in objs:
-                    s3url = s3.put(key, obj)
-                    assert s3url in expected
-                    s3obj = s3.get(key)
-                    assert s3obj.key == key
-                    assert_results([s3obj], {s3url: expected[s3url]}, upload_args=args)
-                    assert s3obj.blob == to_bytes(obj)
-                    # put with overwrite disabled
-                    s3url = s3.put(key, "random_value", overwrite=False)
-                    assert s3url in expected
-                    s3obj = s3.get(key)
-                    assert s3obj.key == key
-                    assert_results([s3obj], {s3url: expected[s3url]}, upload_args=args)
-                    assert s3obj.blob == to_bytes(obj)
+    upload_args = [s3_upload_args, None]
+    for args in upload_args:
+        with S3(s3root=s3root, upload_args=args) as s3:
+            for key, obj in objs:
+                s3url = s3.put(key, obj)
+                assert s3url in expected
+                s3obj = s3.get(key)
+                assert s3obj.key == key
+                assert_results([s3obj], {s3url: expected[s3url]}, upload_args=args)
+                assert s3obj.blob == to_bytes(obj)
+                # put with overwrite disabled
+                s3url = s3.put(key, "random_value", overwrite=False)
+                assert s3url in expected
+                s3obj = s3.get(key)
+                assert s3obj.key == key
+                assert_results([s3obj], {s3url: expected[s3url]}, upload_args=args)
+                assert s3obj.blob == to_bytes(obj)
 
 
 @pytest.mark.parametrize("inject_failure_rate", [0, 10, 50, 90])


### PR DESCRIPTION
Currently, Netflix's Metaflow doesn't allow users to customise their s3 upload settings (including server-side-encryption). These changes enable users to specify their upload settings via parameters of format METAFLOW_UPLOAD_ARGS_S3_[Key].

E.g.

"METAFLOW_UPLOAD_ARGS_S3_ServerSideEncryption": "AES256"
"METAFLOW_UPLOAD_ARGS_S3_ACL": "Private"
"METAFLOW_UPLOAD_ARGS_S3_ContentLanguage": "en"


